### PR TITLE
Stack layout broken when relabeling node

### DIFF
--- a/js/adt/stack.js
+++ b/js/adt/stack.js
@@ -55,11 +55,11 @@ export class Stack {
             item.prev.next = item;
             this.#head = item;
         }
-        this.#measureText(item.node.label);
+        this.measureWidth(item.node.label);
         this.#size++;
     }
 
-    #measureText(text) {
+    measureWidth(text) {
         if (text) {
             let[w, h] = this.#graphics.measureText(text);
             this.#maxTextW = Math.max(this.#maxTextW, w);
@@ -86,7 +86,7 @@ export class Stack {
         item.next.prev = item.prev;
         this.#size--;
         this.#head = (this.#size == 0) ? null : item.next;
-        this.#measureText();
+        this.measureWidth();
         return item.node;
     }
 
@@ -113,7 +113,7 @@ export class Stack {
             }
             this.#size--;
         }
-        this.#measureText();
+        this.measureWidth();
     }
 
     peek() {

--- a/js/main.js
+++ b/js/main.js
@@ -246,6 +246,7 @@ ctxMenuCanvas.addContextMenuListener('hCtxMenuCanvas_Help', () => {
 // #region - Node context menu handlers
 ctxMenuNode.addContextMenuListener('hCtxMenuNode_Label', (_, value) => {
   let prevLabel = graph.reLabel(clickedNode, value);
+  stack.measureWidth();
   repaint();
 });
 


### PR DESCRIPTION
When a node is relabeled, before repainting the entire graph, the stack remeasures its text width.
Fixes #12