### PR TITLE
Add support for drawing bidirectional edges with Shift + Ctrl + drag

### DIFF
--- a/GraphVisualizer/js/adt/graph.js
+++ b/GraphVisualizer/js/adt/graph.js
@@ -4,7 +4,7 @@ import { Direction } from "./edge.js";
 
 export let SCALE = 0;
 export const LINE_WIDTH = [1, 0.6, 0.5];
-export const RADIUS = [16, 10, 6];
+export const RADIUS = [16, 12, 8];
 export const FONT = ["bold 14px Consolas", "12px Consolas", null]
 export const ARROW_WIDTH = [5, 3, 2];
 export const ARROW_LENGTH = [8, 5, 3];
@@ -161,7 +161,13 @@ export class Graph {
         return edge;
     }
 
-    addEdge(fromNode, toNode) {
+    hasEdge(fromNode, toNode, bidirectional) {
+        return bidirectional
+            ? fromNode.hasEdge(toNode) && toNode.hasEdge(fromNode)
+            : fromNode.hasEdge(toNode);
+    }
+
+    addEdge(fromNode, toNode, bidirectional) {
         if (!fromNode.hasEdge(toNode)) {
             fromNode.addEdge(toNode);
             let edge = this.edges.filter(e => e.matchesNodes(fromNode, toNode))[0];
@@ -171,15 +177,32 @@ export class Graph {
                 edge.addDirection(fromNode, toNode);
             }
         }
+        if (bidirectional && !toNode.hasEdge(fromNode)) {
+            toNode.addEdge(fromNode);
+            let edge = this.edges.filter(e => e.matchesNodes(toNode, fromNode))[0];
+            if (edge == null) {
+                this.edges.push(new Edge(this.#graphics, toNode, fromNode));
+            } else {
+                edge.addDirection(toNode, fromNode);
+            }
+        }
     }
 
-    removeEdge(fromNode, toNode) {
+    removeEdge(fromNode, toNode, bidirectional) {
         if (fromNode.hasEdge(toNode)) {
             fromNode.removeEdge(toNode);
             let edge = this.edges.filter(e => e.matchesNodes(fromNode, toNode))[0];
             edge.removeDirection(fromNode, toNode);
             if (edge.direction == Direction.None) {
                 this.edges = this.edges.filter(e => !e.matchesNodes(fromNode, toNode));
+            }
+        }
+        if (bidirectional && toNode.hasEdge(fromNode)) {
+            toNode.removeEdge(fromNode);
+            let edge = this.edges.filter(e => e.matchesNodes(toNode, fromNode))[0];
+            edge.removeDirection(toNode, fromNode);
+            if (edge.direction == Direction.None) {
+                this.edges = this.edges.filter(e => !e.matchesNodes(toNode, fromNode));
             }
         }
     }

--- a/GraphVisualizer/js/main.js
+++ b/GraphVisualizer/js/main.js
@@ -75,6 +75,7 @@ repaint();
 let hoverNode = null;
 let clickedNode = null;
 let ctrlClicked = false;
+let shiftClicked = false;
 let keyPressed = false;
 let dragging = false;
 
@@ -103,6 +104,7 @@ xferDialog.addCloseListener((event) => {
 // #region - key event handlers
 document.addEventListener('keydown', (event) => {
   ctrlClicked = event.ctrlKey || event.metaKey;
+  shiftClicked = event.shiftKey;
   
   if (!keyPressed && hoverNode != null) {
     switch(event.key.toUpperCase()) {
@@ -128,13 +130,12 @@ document.addEventListener('keydown', (event) => {
         break;
     }
   }
-
   keyPressed = true;
 });
 
 document.addEventListener('keyup', (event) => {
   ctrlClicked = event.ctrlKey || event.metaKey;
-
+  shiftClicked = event.shiftKey;
   keyPressed = false;
 });
 // #endregion - key event handlers
@@ -172,7 +173,6 @@ hCanvas.addEventListener('mousemove', (event) => {
             hNodeState.textContent = "";
         }
     }
-    
   } else if (clickedNode != null) {
     // in the middle of {drag} that started over a node (clickedNode)
     if (ctrlClicked) {
@@ -220,10 +220,10 @@ hCanvas.addEventListener('mouseup', (event) => {
     // if {control-drag}, meaning control pressed, started on a node and ended on a different node)...
     if (ctrlClicked && clickedNode != null && droppedNode != null && clickedNode != droppedNode) {
       // => reset edge from clickedNode to droppedNode
-      if (!clickedNode.hasEdge(droppedNode)) {
-        graph.addEdge(clickedNode, droppedNode);
+      if (!graph.hasEdge(clickedNode, droppedNode, shiftClicked)) {
+        graph.addEdge(clickedNode, droppedNode, shiftClicked);
       } else {
-        graph.removeEdge(clickedNode, droppedNode);
+        graph.removeEdge(clickedNode, droppedNode, shiftClicked);
       }
     } else if (clickedNode != null) {
       // otherwise, if drag was just moving a node, need to resort all edges across all nodes


### PR DESCRIPTION
Allows drawing faster complex undirected graphs (each edge is bidirectional) by pressing both Shift and Ctrl while dragging.